### PR TITLE
Update zll-rgbw-bulb.groovy

### DIFF
--- a/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
+++ b/devicetypes/smartthings/zll-rgbw-bulb.src/zll-rgbw-bulb.groovy
@@ -51,6 +51,7 @@ metadata {
         fingerprint profileId: "C05E", inClusters: "0000,0003,0004,0005,0006,0008,0300,1000", outClusters: "0019", manufacturer: "Philips", model: "LST001", deviceJoinName: "Philips Hue Lightstrip"
         fingerprint profileId: "C05E", inClusters: "0000,0003,0004,0005,0006,0008,0300,1000", outClusters: "0019", manufacturer: "Philips", model: "LST002", deviceJoinName: "Philips Hue Lightstrip"
         fingerprint profileId: "C05E", inClusters: "0000, 0003, 0004, 0005, 0006, 0008, 0300", outClusters: "0019", manufacturer: "innr", model: "RB 185 C", deviceJoinName: "innr Smart Bulb RGBW"
+        fingerprint profileId: "C05E", inClusters: "0000,0003,0004,0005,0006,0008,0300,0B05,1000,FC0F", outClusters: "0019", "manufacturer":"LEDVANCE", "model":"CLA60 RGBW Z3", deviceJoinName:"OSRAM/LEDVANCE CLA60 RGBW Z3"
     }
 
     // UI tile definitions


### PR DESCRIPTION
Change:

Added fingerprint for OSRAM/LEDVANCE CLA60 RGBW Z3.  Bulbs are boxed as Osram Smart+ Classic E27 Multicolor but when pairing with Zigbee have manufacturer LEDVANCE and model CLA60 RGBW Z3.  As a consequnce not recognised for what they are and show up as Things.

I have published this locally on my Smartthings hub and these bulbs are now recognised when added rather than showing up as "Thing".  However, as this is the firts time I have added a device fingerprint, it would make sense for someone more familiar to take a look.  In particular, the cluster 0B05 which I extracted from the raw description appears out of place when compared with other Osram RGBW bulbs.
